### PR TITLE
Update pyproject.toml: Fix build for newer versions of hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dependencies = [
 "Homepage" = "https://github.com/KatherLab/barspoon-transformer"
 "Bug Tracker" = "https://github.com/KatherLab/barspoon-transformer/issues"
 
+[tool.hatch.build.targets.wheel]
+packages = ["barspoon"]
+
 [project.scripts]
 "barspoon-train" = "barspoon.train:main"
 "barspoon-deploy" = "barspoon.deploy:main"


### PR DESCRIPTION
Hatchling now does not build if the project name differs from the package name.